### PR TITLE
Version 8.1.7.1

### DIFF
--- a/AdKats.cs
+++ b/AdKats.cs
@@ -21,11 +21,11 @@
  * Work on fork by Hedius (Version >= 8.0.0.0)
  *
  * AdKats.cs
- * Version 8.1.7.0
- * 19-OCT-2022
+ * Version 8.1.7.1
+ * 15-DEC-2022
  *
  * Automatic Update Information
- * <version_code>8.1.7.0</version_code>
+ * <version_code>8.1.7.1</version_code>
  */
 
 using System;
@@ -68,7 +68,7 @@ namespace PRoConEvents
     {
 
         //Current Plugin Version
-        private const String PluginVersion = "8.1.7.0";
+        private const String PluginVersion = "8.1.7.1";
 
         public enum GameVersionEnum
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1587,3 +1587,19 @@ Added small improvements to fuzzy player match response text.</li>
 <ul>
     <li><b>No upgrade SQL required.</b></li>
 </ul>
+
+<h4>8.1.7.1 (15-DEC-2022)</h4>
+<b>Enhancements</b><br/>
+<ul>
+	<li>None</li>
+</ul>
+<b>Changes</b><br/>
+<ul>
+	<li>Merge upstream release 7.6.1.3 into E4GLAdKats</li>
+	<li>Only import active bans into the PRoCon ban list @Prophet731</li>
+</ul>
+<b>Bugs Fixed</b><br/>
+<ul>
+	<li>Updated github URLs to new domain (raw.githubusercontent.com) @Prophet731</li>
+</ul>
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[//]: # "<latest_stable_release>8.1.7.0</latest_stable_release>"
+[//]: # "<latest_stable_release>8.1.7.1</latest_stable_release>"
 <p>
     <a name=adkats />
     <img src="https://i.imgur.com/r9pwH3A.png" alt="AdKats Advanced In-Game Admin Tools">


### PR DESCRIPTION
<h4>8.1.7.1 (15-DEC-2022)</h4>
<b>Enhancements</b><br/>
<ul>
	<li>None</li>
</ul>
<b>Changes</b><br/>
<ul>
	<li>Merge upstream release 7.6.1.3 into E4GLAdKats</li>
	<li>Only import active bans into the PRoCon ban list @Prophet731</li>
</ul>
<b>Bugs Fixed</b><br/>
<ul>
	<li>Updated github URLs to new domain (raw.githubusercontent.com) @Prophet731</li>
</ul>