### PR TITLE
Version 8.1.9.0

### DIFF
--- a/AdKats.cs
+++ b/AdKats.cs
@@ -21,11 +21,11 @@
  * Work on fork by Hedius (Version >= 8.0.0.0)
  *
  * AdKats.cs
- * Version 8.1.8.0
- * 13-JAN-2023
+ * Version 8.1.9.0
+ * 18-FEB-2023
  *
  * Automatic Update Information
- * <version_code>8.1.8.0</version_code>
+ * <version_code>8.1.9.0</version_code>
  */
 
 using System;
@@ -68,7 +68,7 @@ namespace PRoConEvents
     {
 
         //Current Plugin Version
-        private const String PluginVersion = "8.1.8.0";
+        private const String PluginVersion = "8.1.9.0";
 
         public enum GameVersionEnum
         {
@@ -1117,7 +1117,7 @@ namespace PRoConEvents
 
         public String GetPluginName()
         {
-            return "AdKats - Advanced In-Game Admin";
+            return "E4GLAdKats - Advanced In-Game Admin";
         }
 
         public String GetPluginVersion()

--- a/AdKats.cs
+++ b/AdKats.cs
@@ -36087,7 +36087,7 @@ namespace PRoConEvents
                 }
                 else {
                     if (record.record_source != ARecord.Sources.InGame && record.record_source != ARecord.Sources.Automated && record.record_source != ARecord.Sources.ServerCommand) {
-                        SendMessageToSource(record, "You issued a LANGUAGE PUNISH " + record.GetTargetNames() + " for " + record.record_message);
+                        SendMessageToSource(record, "You issued a LANGUAGE PUNISH on " + record.GetTargetNames() + " for " + record.record_message);
                     }
 
                     AdminSayMessage(Log.FBold(Log.CRed(record.GetTargetNames() + " LANGUAGE PUNISHED" + (_ShowAdminNameInAnnouncement ? (" by " + record.GetSourceName()) : ("")) + " for " + record.record_message)));
@@ -36120,7 +36120,7 @@ namespace PRoConEvents
                          record.record_source != ARecord.Sources.Automated &&
                          record.record_source != ARecord.Sources.ServerCommand)
                      {
-                         SendMessageToSource(record, "You issued a LANGUAGE RESET " + record.GetTargetNames() + " for " + record.record_message);
+                         SendMessageToSource(record, "You issued a LANGUAGE RESET on " + record.GetTargetNames() + " for " + record.record_message);
                      }
                      ExecuteCommand("procon.protected.plugins.call", "LanguageEnforcer", "RemoteManuallyResetPlayer", GetType().Name, record.target_player.player_name, record.target_player.player_guid);
                  }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1613,7 +1613,23 @@ Added small improvements to fuzzy player match response text.</li>
 </ul>
 <b>Changes</b><br/>
 <ul>
-	<liNone</li>
+	<li>None</li>
+</ul>
+<b>Bugs Fixed</b><br/>
+<ul>
+	<li>None</li>
+</ul>
+
+<h4>8.1.9.0 (18-FEB-2023)</h4>
+<b>Enhancements</b><br/>
+<ul>
+	<li>New commands: !lpunish and !lreset</li>
+	<li>These commands integrate together with E4GL's LanguageEnforcer fork to allow admins to issue language punishments and resets of the counter over the Language plugin.</li>
+	<li>This has been implemented to allow auditing of language punishments.</li>
+</ul>
+<b>Changes</b><br/>
+<ul>
+	<li>Report war responses tell people to join the discord now. (Instead of teamspeak).</li>
 </ul>
 <b>Bugs Fixed</b><br/>
 <ul>

--- a/README.md
+++ b/README.md
@@ -549,6 +549,12 @@
     Direct temp-ban and ban are of course still available for hacking/glitching situations, but that is the ONLY time
     they should be used.
 </p>
+<h3>LanguageEnforcer Integration</h3>
+<p>
+    This plugin integrates with E4GLs LanguageEnforcer for issuing commands
+    from AdKats. Admins can use the commands !lpunish and !lreset to manually issue LanguageEnforcer punishments on players.
+    Furthermore, this custom version of the plugin comes with temp and perma mute support.
+</p>
 <h3>Player Reputation System</h3>
 <p>
     Reputation is a numeric for how helpful a player is to the server.
@@ -2746,6 +2752,48 @@ plugin.CallOtherPlugin("AdKats", "IssueCommand", command);
         </td>
     </tr>
 </table>
+<h3>LanguageEnforcer Integration Commands</h3>
+<table>
+    <tr>
+        <td><b>Command</b></td>
+        <td><b>Default Text</b></td>
+        <td><b>Params</b></td>
+        <td><b>Description</b></td>
+    </tr>
+    <tr>
+        <td><b>Issue Language Punish</b></td>
+        <td>lpunish</td>
+	<td>
+            None<br/>
+            OR<br/>
+            [player][reason]<br/>
+            OR<br/>
+            [reportID]<br/>
+            OR<br/>
+            [reportID][reason]
+        </td>
+        <td>
+	    The in-game command for issuing a language punishment over LanguageEnforcer. Requires LanguageEnforcer to be installed and enabled.
+        </td>
+    </tr>
+    <tr>
+        <td><b>Issue Language Reset</b></td>
+	 <td>lreset</td>
+	<td>
+            None<br/>
+            OR<br/>
+            [player][reason]<br/>
+            OR<br/>
+            [reportID]<br/>
+            OR<br/>
+            [reportID][reason]
+        </td>
+        <td>
+	    The in-game command for issuing a counter reset over LanguageEnforcer. Resets all points and sets the the player to a clean state.
+        </td>
+    </tr>
+</table>
+
 <h3>Maintenance Commands</h3>
 <table>
     <tr>

--- a/adkats.sql
+++ b/adkats.sql
@@ -327,7 +327,8 @@ REPLACE INTO `adkats_commands` VALUES(152, 'Active', 'player_watchlist_remove', 
 REPLACE INTO `adkats_commands` VALUES(153, 'Active', 'player_persistentmute_force', 'Log', 'Persistent Force Mute Player', 'fmute', TRUE, 'AnyHidden');
 REPLACE INTO `adkats_commands` VALUES(154, 'Active', 'player_whitelistmoveprotection', 'Log', 'Move Protection Whitelist Player', 'movewhitelist', TRUE, 'Any');
 REPLACE INTO `adkats_commands` VALUES(155, 'Active', 'player_whitelistmoveprotection_remove', 'Log', 'Remove Move Protection Whitelist', 'unmovewhitelist', TRUE, 'Any');
-REPLACE INTO `adkats_commands` VALUES(156, 'Active', 'player_language_punish', 'Log', 'Issue LanguageEnforcer Punish', 'lpunish', TRUE, 'Any');
+REPLACE INTO `adkats_commands` VALUES(156, 'Active', 'player_language_punish', 'Log', 'Issue Language Punish', 'lpunish', TRUE, 'Any');
+REPLACE INTO `adkats_commands` VALUES(157, 'Active', 'player_language_reset', 'Log', 'Issue Language Counter Reset', 'lreset', TRUE, 'Any');
 
 
 

--- a/adkats.sql
+++ b/adkats.sql
@@ -327,6 +327,7 @@ REPLACE INTO `adkats_commands` VALUES(152, 'Active', 'player_watchlist_remove', 
 REPLACE INTO `adkats_commands` VALUES(153, 'Active', 'player_persistentmute_force', 'Log', 'Persistent Force Mute Player', 'fmute', TRUE, 'AnyHidden');
 REPLACE INTO `adkats_commands` VALUES(154, 'Active', 'player_whitelistmoveprotection', 'Log', 'Move Protection Whitelist Player', 'movewhitelist', TRUE, 'Any');
 REPLACE INTO `adkats_commands` VALUES(155, 'Active', 'player_whitelistmoveprotection_remove', 'Log', 'Remove Move Protection Whitelist', 'unmovewhitelist', TRUE, 'Any');
+REPLACE INTO `adkats_commands` VALUES(156, 'Active', 'player_language_punish', 'Log', 'Issue LanguageEnforcer Punish', 'lpunish', TRUE, 'Any');
 
 
 

--- a/adkatsreputationstats.json
+++ b/adkatsreputationstats.json
@@ -898,5 +898,10 @@
     "command_typeaction": "156|156",
     "target_weight": -10,
     "source_weight": 0.5
+  },
+  {
+    "command_typeaction": "157|157",
+    "target_weight": 8,
+    "source_weight": 0.5
   }
 ] 

--- a/adkatsreputationstats.json
+++ b/adkatsreputationstats.json
@@ -846,7 +846,7 @@
   },
   {
     "command_typeaction": "146|146",
-    "target_weight": 10,
+    "target_weight": 8,
     "source_weight": 0.5
   },
   {
@@ -866,7 +866,7 @@
   },
   {
     "command_typeaction": "150|150",
-    "target_weight": 10,
+    "target_weight": 8,
     "source_weight": 1
   },
   {
@@ -893,5 +893,10 @@
     "command_typeaction": "155|155",
     "target_weight": 0,
     "source_weight": 0
+  },
+  {
+    "command_typeaction": "156|156",
+    "target_weight": -10,
+    "source_weight": 0.5
   }
 ] 


### PR DESCRIPTION
<h4>8.1.9.0 (18-FEB-2023)</h4>
<b>Enhancements</b><br/>
<ul>
	<li>New commands: !lpunish and !lreset</li>
	<li>These commands integrate together with E4GL's LanguageEnforcer fork to allow admins to issue language punishments and resets of the counter over the Language plugin.</li>
	<li>This has been implemented to allow auditing of language punishments.</li>
</ul>
<b>Changes</b><br/>
<ul>
	<li>Report war responses tell people to join the discord now. (Instead of teamspeak).</li>
</ul>
<b>Bugs Fixed</b><br/>
<ul>
	<li>None</li>
</ul>